### PR TITLE
fix testName configuration setting not being populated

### DIFF
--- a/src/PlaywrightAvailabilityTester.ts
+++ b/src/PlaywrightAvailabilityTester.ts
@@ -183,7 +183,7 @@ export class PlaywrightAvailabilityTester {
       // APPSETTING_TESTNAME can be used to override that
       let testName = this.testName;
       if (!testName || testName == "") {
-        location = process.env.APPSETTING_TESTNAME || process.env.APPSETTING_WEBSITE_SITE_NAME || "NO_TESTNAME";
+        testName = process.env.APPSETTING_TESTNAME || process.env.APPSETTING_WEBSITE_SITE_NAME || "NO_TESTNAME";
       }
       bci.testName = testName;
 


### PR DESCRIPTION
There is a bug when assigning the Configuration Setting `TestName`. It was assigning it to the `location` variable instead, making the test showing empty testName in application insights.

This fix issue #12 